### PR TITLE
Implementation of an xorshift random number generator

### DIFF
--- a/grass/process.c
+++ b/grass/process.c
@@ -12,6 +12,8 @@
 #include "syscall.h"
 #include <string.h>
 
+static int s_iSeed = 0;
+
 void intr_entry(int id);
 
 void excp_entry(int id) {
@@ -77,6 +79,23 @@ void proc_free(int pid) {
             earth->mmu_free(proc_set[i].pid);
             proc_set[i].status = PROC_UNUSED;
         }
+}
+
+// implemented from http://www.jstatsoft.org/v08/i14/paper
+// https://en.wikipedia.org/wiki/Xorshift
+void srand(unsigned int seed)
+{
+    s_iSeed = seed;
+}
+
+// implemented from http://www.jstatsoft.org/v08/i14/paper
+// https://en.wikipedia.org/wiki/Xorshift
+unsigned int rand()
+{
+    s_iSeed ^= s_iSeed << 13;
+    s_iSeed ^= s_iSeed >> 17;
+    s_iSeed ^= s_iSeed << 5;
+    return s_iSeed;
 }
 
 void proc_set_ready(int pid) { proc_set_status(pid, PROC_READY); }


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes kernel panics, when trying to use rand from the standard library. Implemented from [this paper](http://www.jstatsoft.org/v08/i14/paper). 

Does this close any currently open issues?
------------------------------------------
NONE open.


Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------

- It is the exact implementation I used for my scheduler, so hopefully, by me giving this to you, grade-checking software won't false-positive me... 

- Right now rand and srand are only declared and defined in process' compilation unit, but it would be easier to change that if so needed.

Where has this been tested?
---------------------------
**Operating System:** Egos-2000 / linux

**Platform:** x86-64

**Target Platform:** riscv

**Toolchain Version:** N/A

**SDK Version:** N/A
